### PR TITLE
Increase PHP memory limit

### DIFF
--- a/index.php
+++ b/index.php
@@ -2,7 +2,7 @@
 require_once('./util.php');
 define('SIANCT_TRUSTED_REQUEST', FALSE);
 //define('SIANCT_TRUSTED_REQUEST', TRUE);
-ini_set('memory_limit', '2G');
+ini_set('memory_limit', '4G');
 
 //-- Configuration:
 


### PR DESCRIPTION
The cache file can get rather large, so increasing the PHP memory limit to prevent out of memory errors.